### PR TITLE
feat: コミット推移グラフの日付の下にその日・その週コミット数が一位だった人のアイコンを載せる

### DIFF
--- a/src/app/api/contributions/all/route.ts
+++ b/src/app/api/contributions/all/route.ts
@@ -91,7 +91,8 @@ export async function GET(request: Request) {
     // 最終的なデータ整形
     const formattedData = entries.map((entry) => {
       let level: 0 | 1 | 2 | 3 | 4 = 0;
-      if (entry.totalCount > 0) {
+      // ★ maxCount > 0 を追加して 0除算を完全に防ぐ
+      if (entry.totalCount > 0 && maxCount > 0) {
         if (maxCount <= 4) {
           level = Math.min(entry.totalCount, 4) as 1 | 2 | 3 | 4;
         } else {
@@ -103,11 +104,14 @@ export async function GET(request: Request) {
         }
       }
 
+      // ★ シニアの提案通り、表示用のデータだけを返す（ロジックをバックエンドに寄せる）
       const safeTopUser = entry.topUser
         ? {
             count: entry.topUser.count,
-            isAnonymous: entry.topUser.isAnonymous,
-            githubName: entry.topUser.isAnonymous ? "anonymous" : entry.topUser.githubName,
+            displayName: entry.topUser.isAnonymous ? "匿名ユーザー" : entry.topUser.githubName,
+            avatarUrl: entry.topUser.isAnonymous
+              ? null
+              : `https://github.com/${entry.topUser.githubName}.png`,
           }
         : null;
 

--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -37,9 +37,9 @@ interface CustomXAxisTickProps {
 }
 
 interface TopUser {
-  githubName: string;
   count: number;
-  isAnonymous: boolean;
+  displayName: string;
+  avatarUrl: string | null;
 }
 
 interface ApiDay {
@@ -59,7 +59,7 @@ interface DayData {
 
 //「匿」アイコン＆GitHubアイコンを表示する共通コンポーネント
 const TopUserAvatar = ({ topUser, size = 20 }: { topUser: TopUser; size?: number }) => {
-  if (topUser.isAnonymous) {
+  if (!topUser.avatarUrl) {
     return (
       <div
         style={{
@@ -82,14 +82,9 @@ const TopUserAvatar = ({ topUser, size = 20 }: { topUser: TopUser; size?: number
   }
   return (
     <img
-      src={`https://github.com/${topUser.githubName}.png`}
-      alt={topUser.githubName}
-      style={{
-        width: size,
-        height: size,
-        borderRadius: "50%",
-        border: "1px solid #484f58",
-      }}
+      src={topUser.avatarUrl}
+      alt={topUser.displayName}
+      style={{ width: size, height: size, borderRadius: "50%", border: "1px solid #484f58" }}
     />
   );
 };
@@ -209,9 +204,7 @@ const CustomTooltip = ({ active, payload }: CustomTooltipProps) => {
           }}
         >
           <TopUserAvatar topUser={data.topUser} size={16} />
-          <span style={{ color: "#c9d1d9", fontSize: 11 }}>
-            {data.topUser.isAnonymous ? "匿名ユーザー" : data.topUser.githubName} が1位!
-          </span>
+          <span style={{ color: "#c9d1d9", fontSize: 11 }}>{data.topUser.displayName} が1位!</span>
         </div>
       )}
     </div>


### PR DESCRIPTION
## 概要
草グラフ（コミット推移）の日付の下に、その日のMVPユーザーのアイコンを表示する機能を追加しました。

## 対応内容
- `CustomXAxisTick` を使用し、日別MVPユーザーのアイコン（GitHubアイコンまたは「匿」アイコン）をX軸下に描画
- ツールチップ内にも1位のユーザー情報を表示

## 備考
1年表示の際、アイコンが密集しすぎないよう描画間隔を自動調整するRechartsの仕様を利用しています。

## 関連Issue
Closes #52