### PR TITLE
refactor: auth.tsからGitHub API連携ロジックをuserService.tsに分離

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@prisma/adapter-pg": "^5.22.0",
         "@prisma/client": "^5.22.0",
         "@upstash/redis": "^1.36.3",
+        "@vercel/functions": "^3.4.3",
         "lucide-react": "^0.577.0",
         "next": "16.1.6",
         "next-auth": "^5.0.0-beta.30",
@@ -2532,6 +2533,35 @@
       "license": "MIT",
       "dependencies": {
         "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/@vercel/functions": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.4.3.tgz",
+      "integrity": "sha512-kA14KIUVgAY6VXbhZ5jjY+s0883cV3cZqIU3WhrSRxuJ9KvxatMjtmzl0K23HK59oOUjYl7HaE/eYMmhmqpZzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-web-identity": "*"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-web-identity": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/acorn": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@prisma/adapter-pg": "^5.22.0",
     "@prisma/client": "^5.22.0",
     "@upstash/redis": "^1.36.3",
+    "@vercel/functions": "^3.4.3",
     "lucide-react": "^0.577.0",
     "next": "16.1.6",
     "next-auth": "^5.0.0-beta.30",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -3,6 +3,7 @@ import GitHub from "next-auth/providers/github";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import { prisma } from "@/lib/prisma";
 import { syncUserLanguages } from "@/services/userService";
+import { waitUntil } from "@vercel/functions";
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
   adapter: PrismaAdapter(prisma),
@@ -65,8 +66,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         // ユーザー自身のトークンを取得
         const githubName = profile.login as string;
         const userToken = account.access_token;
-
-        syncUserLanguages(userId, githubName, userToken).catch(console.error);
+        waitUntil(syncUserLanguages(userId, githubName, userToken).catch(console.error));
       }
     },
     async signOut(message) {

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,23 +1,32 @@
 import { prisma } from "@/lib/prisma";
 import { getUserLanguageStats } from "@/lib/github";
 
-// フォールバック用のグローバルトークン（基本はユーザー自身のトークンを使う）
-const FALLBACK_TOKEN = process.env.GITHUB_ACCESS_TOKEN;
-
 export async function syncUserLanguages(userId: string, githubName: string, accessToken?: string) {
-  // ユーザーのトークンを優先し、無ければ環境変数のトークンを使う
-  const token = accessToken || FALLBACK_TOKEN;
-  if (!token || !githubName) return;
+  if (!accessToken || !githubName) {
+    console.warn(`[Sync] トークンまたはGitHub名がないため、${githubName} の同期をスキップします。`);
+    return;
+  }
 
   try {
-    const existingLanguages = await prisma.userLanguage.count({
-      where: { userId: userId },
+    const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+    // 24時間以内に更新された自分の言語データが1件でもあれば、最近同期したとみなす
+    const recentSync = await prisma.userLanguage.findFirst({
+      where: {
+        userId: userId,
+        updatedAt: { gte: oneDayAgo },
+      },
     });
 
-    if (existingLanguages > 0) return;
+    if (recentSync) {
+      console.log(`[Sync] ${githubName} の言語データは24時間以内に同期済みのためスキップします。`);
+      return;
+    }
+
+    console.log(`[Sync] ${githubName} の言語データの同期を開始します...`);
 
     const report = await getUserLanguageStats(githubName, {
-      token: token,
+      token: accessToken,
       concurrency: 5,
     });
 
@@ -31,6 +40,8 @@ export async function syncUserLanguages(userId: string, githubName: string, acce
         }),
       ),
     );
+
+    console.log(`[Sync] ${githubName} の言語データの同期が完了しました。`);
   } catch (e) {
     console.error(`[SyncError] Failed to fetch languages for ${githubName}:`, e);
   }


### PR DESCRIPTION
## 概要
アーキテクチャ改善のリファクタリングです。
これまで src/auth.ts の signIn イベント内に直接記述されていた「GitHub からの言語データ取得および DB 保存」のロジックを、サービス層（src/services/userService.ts）に切り出しました。

## 関連Issue
Closes #35